### PR TITLE
Fix for Request N read

### DIFF
--- a/RSocket.Core/RSocketProtocol.cs
+++ b/RSocket.Core/RSocketProtocol.cs
@@ -155,7 +155,7 @@ namespace RSocket
 			public RequestChannel(in Header header, ref SequenceReader<byte> reader)
 			{
 				Header = header;
-				reader.TryRead(out int initialRequest); InitialRequest = initialRequest;
+				reader.TryReadBigEndian(out int initialRequest); InitialRequest = initialRequest;
 				TryReadRemaining(header, InnerLength, ref reader, out MetadataLength, out DataLength);
 			}
 
@@ -211,7 +211,7 @@ namespace RSocket
 			public RequestStream(in Header header, ref SequenceReader<byte> reader)
 			{
 				Header = header;
-				reader.TryRead(out int initialRequest); InitialRequest = initialRequest;
+				reader.TryReadBigEndian(out int initialRequest); InitialRequest = initialRequest;
 				TryReadRemaining(header, InnerLength, ref reader, out MetadataLength, out DataLength);
 			}
 
@@ -359,7 +359,7 @@ namespace RSocket
 			public RequestN(in Header header, ref SequenceReader<byte> reader)
 			{
 				Header = header;
-				reader.TryRead(out int requestNumber); RequestNumber = requestNumber;
+				reader.TryReadBigEndian(out int requestNumber); RequestNumber = requestNumber;
 			}
 
 			public bool Validate(bool canContinue = false)


### PR DESCRIPTION
Hi,

I'm playing with setting up RSocket.NET based server and while trying to access it from Java based client, the `REQUEST_STREAM` frame is always failing validation. The reason seems to be that *Request N* is not being read as big endian. I've applied the change and issue seems to be resolved.