### PR TITLE
fix:  improperly formed mime-type changed from binary to application/…

### DIFF
--- a/RSocket.Core/RSocketOptions.cs
+++ b/RSocket.Core/RSocketOptions.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 
 namespace RSocket
 {
 	public class RSocketOptions
 	{
 		public const int INITIALDEFAULT = int.MinValue;
-		public const string BINARYMIMETYPE = "binary";
+		public const string BINARYMIMETYPE = "application/octet-stream";
 
 		public TimeSpan KeepAlive { get; set; }
 		public TimeSpan Lifetime { get; set; }


### PR DESCRIPTION
In case we do not use the LoopbackTransport, (either TCP or WS) we need to specify a default BINARYMIMETYPE
The previous was specified but incorrect. 