### PR TITLE
Fixed problem with automatic responses to KEEPALIVE frames from server.

### DIFF
--- a/RSocket.Core/IRSocketProtocol.cs
+++ b/RSocket.Core/IRSocketProtocol.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers;
 
 namespace RSocket
@@ -15,5 +15,6 @@ namespace RSocket
 		void RequestResponse(in RSocketProtocol.RequestResponse message, ReadOnlySequence<byte> metadata, ReadOnlySequence<byte> data);
 		void RequestFireAndForget(in RSocketProtocol.RequestFireAndForget message, ReadOnlySequence<byte> metadata, ReadOnlySequence<byte> data);
 		void RequestChannel(in RSocketProtocol.RequestChannel message, ReadOnlySequence<byte> metadata, ReadOnlySequence<byte> data);
+		void KeepAlive(in RSocketProtocol.KeepAlive message);
 	}
 }

--- a/RSocket.Core/RSocket.cs
+++ b/RSocket.Core/RSocket.cs
@@ -43,9 +43,9 @@ namespace RSocket
 		/// <returns>The handler task.</returns>
 		public Task Connect(CancellationToken cancel = default) => RSocketProtocol.Handler(this, Transport.Input, cancel);
 		public Task Setup(TimeSpan keepalive, TimeSpan lifetime, string metadataMimeType = null, string dataMimeType = null, ReadOnlySequence<byte> data = default, ReadOnlySequence<byte> metadata = default) => new RSocketProtocol.Setup(keepalive, lifetime, metadataMimeType: metadataMimeType, dataMimeType: dataMimeType, data: data, metadata: metadata).WriteFlush(Transport.Output, data: data, metadata: metadata);
-
-
+		public Task KeepAlive(TimeSpan keepalive, TimeSpan lifetime, string metadataMimeType = null, string dataMimeType = null, ReadOnlySequence<byte> data = default, ReadOnlySequence<byte> metadata = default) => new RSocketProtocol.KeepAlive(0,false, data: data).WriteFlush(Transport.Output );
 		//TODO SPEC: A requester MUST not send PAYLOAD frames after the REQUEST_CHANNEL frame until the responder sends a REQUEST_N frame granting credits for number of PAYLOADs able to be sent.
+		public virtual void KeepAlive(in RSocketProtocol.KeepAlive value) => new RSocketProtocol.KeepAlive(0, false).WriteFlush(Transport.Output);
 
 		public virtual IAsyncEnumerable<T> RequestChannel<TSource, T>(IAsyncEnumerable<TSource> source, Func<TSource, ReadOnlySequence<byte>> sourcemapper,
 			Func<(ReadOnlySequence<byte> data, ReadOnlySequence<byte> metadata), T> resultmapper,
@@ -214,5 +214,6 @@ namespace RSocket
 			await source.ForEachAsync(item => action(item), cancel);
 			await final?.Invoke();
 		}
+
 	}
 }

--- a/RSocket.Core/RSocketProtocol.Handler.cs
+++ b/RSocket.Core/RSocketProtocol.Handler.cs
@@ -20,6 +20,7 @@ namespace RSocket
 		static void OnRequestResponse(IRSocketProtocol sink, in RSocketProtocol.RequestResponse message, ReadOnlySequence<byte> metadata, ReadOnlySequence<byte> data) => sink.RequestResponse(message, metadata, data);
 		static void OnRequestFireAndForget(IRSocketProtocol sink, in RSocketProtocol.RequestFireAndForget message, ReadOnlySequence<byte> metadata, ReadOnlySequence<byte> data) => sink.RequestFireAndForget(message, metadata, data);
 		static void OnRequestChannel(IRSocketProtocol sink, in RSocketProtocol.RequestChannel message, ReadOnlySequence<byte> metadata, ReadOnlySequence<byte> data) => sink.RequestChannel(message, metadata, data);
+		static void OnRequestKeepAlive(IRSocketProtocol sink, in RSocketProtocol.KeepAlive message) => sink.KeepAlive(message);
 
 		static public async Task Handler(IRSocketProtocol sink, PipeReader pipereader, CancellationToken cancellation)
 		{
@@ -61,6 +62,7 @@ namespace RSocket
 						break;
 					case Types.KeepAlive:
 						var keepalive = new KeepAlive(header, ref reader);
+						if (keepalive.Validate( true )) { OnRequestKeepAlive(sink, keepalive); }
 						break;
 					case Types.Request_Response:
 						var requestresponse = new RequestResponse(header, ref reader);

--- a/RSocket.Core/RSocketProtocol.cs
+++ b/RSocket.Core/RSocketProtocol.cs
@@ -442,7 +442,7 @@ namespace RSocket
 
 			public bool Validate(bool canContinue = false)
 			{
-				if (Header.Stream == 0) { return true; }	//SPEC: KEEPALIVE frames with Stream ID 0 require no further validation
+				if (Header.Stream == 0) { return true; } else { return false; }	//SPEC: KEEPALIVE frames with Stream ID 0 require no further validation
 				if (LastReceivedPosition < 0) { return canContinue ? false : throw new ArgumentOutOfRangeException(nameof(LastReceivedPosition), LastReceivedPosition, $"Invalid {nameof(KeepAlive)} Message."); }	//SPEC: Value MUST be > 0. (optional. Set to all 0s when not supported.)
 				else return true;
 			}

--- a/RSocket.Core/RSocketProtocol.cs
+++ b/RSocket.Core/RSocketProtocol.cs
@@ -442,7 +442,7 @@ namespace RSocket
 
 			public bool Validate(bool canContinue = false)
 			{
-				if (Header.Stream == 0) { return canContinue ? false : throw new ArgumentOutOfRangeException(nameof(Header.Stream), $"Invalid {nameof(KeepAlive)} Message."); }		//SPEC: KEEPALIVE frames MUST always use Stream ID 0 as they pertain to the Connection.
+				if (Header.Stream == 0) { return true; }	//SPEC: KEEPALIVE frames with Stream ID 0 require no further validation
 				if (LastReceivedPosition < 0) { return canContinue ? false : throw new ArgumentOutOfRangeException(nameof(LastReceivedPosition), LastReceivedPosition, $"Invalid {nameof(KeepAlive)} Message."); }	//SPEC: Value MUST be > 0. (optional. Set to all 0s when not supported.)
 				else return true;
 			}


### PR DESCRIPTION
Fixed a problem with automatic responses to KEEPALIVE frames from server.

Reponses to the KEEPALIVE frames being sent from the server to the client were not being responded to. This caused a timeout of the connection on the server side after 30 seconds.

I modified the Validate method to return true when Header.Stream == 0. I think this is all that needs to be validated on a KEEPALIVE frame. The code was already present that sends the KEEPALIVE response to the server when Validate returns true.

NOTE: KEEPALIVE frames initiated by the client work fine. These changes only affect the client response to the server KEEPALIVE requests.


